### PR TITLE
Ensure clearing of resource during error path

### DIFF
--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -23,6 +23,10 @@ export const print = async (url, cookies) => {
       userDataDir
     });
 
+    browser.on('disconnected', () => {
+      deleteUserDataDir(userDataDir);
+    });
+
     page = await browser.newPage();
     await page.setCookie(...cookies);
     await page.emulateMediaType('print');
@@ -39,7 +43,5 @@ export const print = async (url, cookies) => {
     if (browser && browser.isConnected()) {
       await browser.close();
     }
-
-    setTimeout(() => deleteUserDataDir(userDataDir));
   }
 }

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -12,23 +12,34 @@ function deleteUserDataDir(dirPath) {
 }
 
 export const print = async (url, cookies) => {
+  let browser = null;
+  let page = null;
   const userDataDir = path.resolve(`temp/puppeteer/${uuidv4()}`);
 
-  const browser = await puppeteer.launch({
-    ignoreHTTPSErrors: true,
-    args: ['--no-sandbox'],
-    userDataDir
-  });
+  try {
+    browser = await puppeteer.launch({
+      ignoreHTTPSErrors: true,
+      args: ['--no-sandbox'],
+      userDataDir
+    });
 
-  const page = await browser.newPage();
-  await page.setCookie(...cookies);
-  await page.emulateMediaType('print');
-  await page.goto(url, { waitUntil: 'networkidle0' });
-  const pdf = await page.pdf({ format: 'A4' });
-  await page.close();
-  await browser.close();
+    page = await browser.newPage();
+    await page.setCookie(...cookies);
+    await page.emulateMediaType('print');
+    await page.goto(url, { waitUntil: 'networkidle0' });
+    const pdf = await page.pdf({ format: 'A4' });
+    return pdf;
+  } catch (error) {
+    throw error;
+  } finally {
+    if (page && !page.isClosed()) {
+      await page.close();
+    }
 
-  setTimeout(() => deleteUserDataDir(userDataDir));
+    if (browser && browser.isConnected()) {
+      await browser.close();
+    }
 
-  return pdf;
+    setTimeout(() => deleteUserDataDir(userDataDir));
+  }
 }


### PR DESCRIPTION
# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue

The puppeteer browser will not be disposed when a crash happens inside `lib/print`'s `print` method .

This PR ensures `browser` clean up logic is called after both good path and exception path.




# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

## Verifying good path

```js
fetch('http://localhost:3000/print', {
  method: 'post',
  headers: { 'content-type': 'application/json' },
  body: JSON.stringify({
    url: 'https://www.example.com'
  }),
});
```

- `L35`: `return pdf` is called
- `L40`: `await page.close();` is called
- `L44`: `await browser.close();` is called
- `L27`: `deleteUserDataDir(userDataDir);` is called


## Verifying exception path
During testing, an exception is triggered by supplying an invalid URL

```js
fetch('http://localhost:3000/print', {
  method: 'post',
  headers: { 'content-type': 'application/json' },
  body: JSON.stringify({
    url: 'http://an-invalid-url'
  }),
});
```

During exception:
- `L37`: `throw error` is called
- `L40`: `await page.close();` is called
- `L44`: `await browser.close();` is called
- `L27`: `deleteUserDataDir(userDataDir);` is called
