### PR TITLE
Rewrite post request to receive list of options

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -26,14 +26,12 @@ app.post('/print', async (req, res, next) => {
     res.send(pdf);
     return;
   } catch (error) {
-    if (error instanceof PulpperatorError) {
-      res
-        .status(400)
-        .send(error.toJson())
-      ;
-      return;
-    }
-    next(error);
+    res
+      .status(error instanceof PulpperatorError ? 400 : 500)
+      .json({
+        error: true,
+        message: error.message
+      });
     return;
   }
 })

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -18,10 +18,12 @@ app.get('/', (req, res) => {
 });
 
 app.post('/print', async (req, res, next) => {
-  const options = req.body.options || [];
+  const url = req.body.url || '';
+  const options = req.body.options || {};
+  const methods = req.body.methods || [];
 
   try {
-    const pdf = await print(options);
+    const pdf = await print(url, options, methods);
     res.contentType("application/pdf");
     res.send(pdf);
     return;

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -18,19 +18,10 @@ app.get('/', (req, res) => {
 });
 
 app.post('/print', async (req, res, next) => {
-  const cookies = req.body.cookies || [];
-  const url = req.body.url;
-
-  if (!url) {
-    const error = new PulpperatorBadRequest('Empty url given');
-    res
-      .status(400)
-      .send(error.toJson());
-    return;
-  }
+  const options = req.body.options || [];
 
   try {
-    const pdf = await print(url, cookies);
+    const pdf = await print(options);
     res.contentType("application/pdf");
     res.send(pdf);
     return;

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -13,9 +13,9 @@ function deleteUserDataDir(dirPath) {
 }
 
 function sanitizePdfArgs(args = {}) {
-  return { 
-    ...(args || {}), 
-    path: null 
+  return {
+    ...(args || {}),
+    path: null
   };
 }
 

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -19,6 +19,13 @@ let methods = [];
 let options = {};
 let url = '';
 
+function clearPdfArgsPath(args = {}) {
+  if (args) {
+    return { ...args, path: null };
+  }
+  return {};
+}
+
 async function generatePdf() {
   let pdfArgs = {};
   let hasMethods = methods && methods.length;

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -97,10 +97,9 @@ export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) =>
   try {
     browser = await launchBrowser(userDataDir);
     page = await launchPage(browser);
-    await callMethods(page, pageMethods);
 
-    const pdf = await generatePdf(page, printUrl, pdfOptions, pageMethods);
-    return pdf;
+    await callMethods(page, pageMethods);
+    return await generatePdf(page, printUrl, pdfOptions, pageMethods);
   } catch (error) {
     throw error;
   } finally {

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -100,8 +100,6 @@ export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) =>
 
     await callMethods(page, pageMethods);
     return await generatePdf(page, printUrl, pdfOptions, pageMethods);
-  } catch (error) {
-    throw error;
   } finally {
     if (page && !page.isClosed()) {
       await page.close();

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -12,28 +12,34 @@ function deleteUserDataDir(dirPath) {
   });
 }
 
-function clearPdfArgsPath(args = {}) {
-  if (args) {
-    return { ...args, path: null };
+function sanitizePdfArgs(args = {}) {
+  return { 
+    ...(args || {}), 
+    path: null 
+  };
+}
+
+async function goToPage(page, url) {
+  try {
+    await page.goto(url);
+  } catch (error) {
+    throw new PuppeteerBadRequest(`Puppeteer page goto error: ${error.message}`);
   }
-  return {};
 }
 
 async function generatePdf(page, printUrl, pdfOptions, pageMethods) {
-  let pdfMethod = pageMethods.find(method => method.name === 'pdf');
-  let pdfArgs = {};
-
-  if (pdfMethod) {
-    pdfArgs = pdfMethod.args || {};
-  } else {
-    try {
-      await page.goto({ url: printUrl })
-    } catch (error) {
-      throw new PuppeteerBadRequest(`Puppeteer page goto error: ${error.message}`);
+  const pdfMethodArgs = pageMethods.reduce((acc, method) => {
+    if (method.name === 'pdf') {
+      acc = method.args ? method.args[0] : {}
     }
-    pdfArgs = pdfOptions;
+    return acc;
+  }, {});
+
+  const pdfArgs = sanitizePdfArgs(pdfMethodArgs || pdfOptions);
+
+  if (pageMethods.length === 0) {
+    goToPage(page, printUrl);
   }
-  pdfArgs = clearPdfArgsPath(pdfArgs);
 
   return page.pdf(pdfArgs);
 }

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -12,13 +12,6 @@ function deleteUserDataDir(dirPath) {
   });
 }
 
-let browser = null;
-let page = null;
-
-let methods = [];
-let options = {};
-let url = '';
-
 function clearPdfArgsPath(args = {}) {
   if (args) {
     return { ...args, path: null };
@@ -108,15 +101,12 @@ async function launchPage() {
 }
 
 export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) => {
-  url = printUrl;
-  options = pdfOptions;
-  methods = pageMethods;
   const userDataDir = path.resolve(`temp/puppeteer/${uuidv4()}`);
 
   try {
-    browser = await launchBrowser(userDataDir);
-    page = await launchPage();
-    
+    let browser = await launchBrowser(userDataDir);
+    let page = await launchPage(browser);
+
     const pdf = await generatePdf();
     return pdf;
   } catch (error) {

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -20,6 +20,16 @@ let options = {};
 let url = '';
 
   if (hasMethods) {
+function filterMethods() {
+  const pdfMethodIndex = methods.findIndex(method => method.name === 'pdf');
+  let filteredMethods = methods;
+
+  if (pdfMethodIndex >= 0) {
+    filteredMethods = methods.slice(0, pdfMethodIndex);
+  }
+
+  return filteredMethods;
+}
     for (const method of methods) { 
       const args = method.args || [];
       try {
@@ -53,16 +63,14 @@ async function launchBrowser(userDataDir) {
   }
 }
 
-async function launchPage(browser, pageOptions) {
+async function launchPage() {
   const page = await browser.newPage();
 
   page.on('error', () => {
     throw new PuppeteerCrash('Puppeteer launch page error');
   });
   
-  if (pageOptions) {
-    await callMethods(page, pageOptions.methods || []);
-  }
+  const filteredMethods = filterMethods(); 
 
   return page;
 }

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -12,8 +12,12 @@ function deleteUserDataDir(dirPath) {
   });
 }
 
-async function callMethods(classObj, methods = []) {
-  const hasMethods = methods && methods.length;
+let browser = null;
+let page = null;
+
+let methods = [];
+let options = {};
+let url = '';
 
   if (hasMethods) {
     for (const method of methods) { 
@@ -63,25 +67,17 @@ async function launchPage(browser, pageOptions) {
   return page;
 }
 
-export const print = async (options = null) => {
-  let browser = null;
-  let page = null;
+export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) => {
+  url = printUrl;
+  options = pdfOptions;
+  methods = pageMethods;
   const userDataDir = path.resolve(`temp/puppeteer/${uuidv4()}`);
 
-  const hasOptions = !!options;
-  let browserOptions = null;
-  let pageOptions = null;
-
-  if (hasOptions) {
-    [browserOptions] = options.filter(option => option.type === 'browser');
-    [pageOptions] = options.filter(option => option.type === 'page');
-  }
-
   try {
-    browser = await launchBrowser(userDataDir, browserOptions);
-    page = await launchPage(browser, pageOptions);
-    const pdf = await page.pdf({format: 'A4'});
-
+    browser = await launchBrowser(userDataDir);
+    page = await launchPage();
+    
+    const pdf = await generatePdf();
     return pdf;
   } catch (error) {
     throw error;

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -54,7 +54,7 @@ function filterMethods() {
 }
 
 async function callMethods(methods = []) {
-  for (const method of methods) { 
+  for (const method of methods) {
     const args = method.args || [];
     try {
       await page[method.name](...args);
@@ -88,16 +88,12 @@ async function launchBrowser(userDataDir) {
 }
 
 async function launchPage() {
-  const page = await browser.newPage();
-
-  page.on('error', () => {
-    throw new PuppeteerCrash('Puppeteer launch page error');
-  });
-  
-  const filteredMethods = filterMethods(); 
-  await callMethods(filteredMethods);
-
-  return page;
+  try {
+    const page = await browser.newPage();
+    return page;
+  } catch (error) {
+    throw new PuppeteerCrash(`Puppeteer launch page error: ${error.message}`);
+  }
 }
 
 export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) => {

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -51,7 +51,7 @@ async function callMethods(page, methods = []) {
     }
 
     try {
-      await page[method.name](...(method.args || {}));
+      await page[method.name](...(method.args || []));
     } catch (error) {
       throw new PuppeteerBadRequest(
         `Puppeteer bad request: ${error.message}`

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -26,22 +26,19 @@ async function generatePdf(page, printUrl, pdfOptions, pageMethods) {
   if (pdfMethod) {
     pdfArgs = pdfMethod.args || {};
   } else {
-    pdfArgs = pdfOptions;
-  }
-  pdfArgs = clearPdfArgsPath(pdfArgs);
-
-  if (pdfMethod) {
     try {
       await page.goto({ url: printUrl })
     } catch (error) {
       throw new PuppeteerBadRequest(`Puppeteer page goto error: ${error.message}`);
     }
+    pdfArgs = pdfOptions;
   }
+  pdfArgs = clearPdfArgsPath(pdfArgs);
 
   return page.pdf(pdfArgs);
 }
 
-async function callMethods(methods = []) {
+async function callMethods(page, methods = []) {
   for (const method of methods) {
     const args = method.args || [];
     const name = method.name || '';
@@ -83,7 +80,7 @@ async function launchBrowser(userDataDir) {
   }
 }
 
-async function launchPage() {
+async function launchPage(browser) {
   try {
     const page = await browser.newPage();
     return page;
@@ -93,12 +90,14 @@ async function launchPage() {
 }
 
 export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) => {
+  let browser = null;
+  let page = null;
   const userDataDir = path.resolve(`temp/puppeteer/${uuidv4()}`);
 
   try {
-    let browser = await launchBrowser(userDataDir);
-    let page = await launchPage(browser);
-    page = await callMethods(pageMethods);
+    browser = await launchBrowser(userDataDir);
+    page = await launchPage(browser);
+    await callMethods(page, pageMethods);
 
     const pdf = await generatePdf(page, printUrl, pdfOptions, pageMethods);
     return pdf;

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -83,14 +83,10 @@ export const print = async (options = null) => {
   }
 
   try {
-    browser = await launchBrowser(userDataDir);
-    page = await launchPage(browser);
+    browser = await launchBrowser(userDataDir, browserOptions);
+    page = await launchPage(browser, pageOptions);
+    const pdf = await page.pdf({format: 'A4'});
 
-    await page.setCookie(...cookies);
-    await page.emulateMediaType('print');
-    await goToPage(page, url);
-
-    const pdf = await page.pdf({ format: 'A4' });
     return pdf;
   } catch (error) {
     throw error;

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -30,15 +30,17 @@ function filterMethods() {
 
   return filteredMethods;
 }
-    for (const method of methods) { 
-      const args = method.args || [];
-      try {
-        await classObj[method.name](...args);
-      } catch (error) {
-        throw new PuppeteerBadRequest(`Puppeteer bad request: ${error.message}`);
-      }
+
+async function callMethods(methods = []) {
+  for (const method of methods) { 
+    const args = method.args || [];
+    try {
+      await page[method.name](...args);
+    } catch (error) {
+      throw new PuppeteerBadRequest(`Puppeteer bad request: ${error.message}`);
     }
   }
+}
 
 async function launchBrowser(userDataDir) {
   try {
@@ -71,6 +73,7 @@ async function launchPage() {
   });
   
   const filteredMethods = filterMethods(); 
+  await callMethods(filteredMethods);
 
   return page;
 }

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -42,24 +42,21 @@ async function generatePdf() {
   return page.pdf(pdfArgs);
 }
 
-function filterMethods() {
-  const pdfMethodIndex = methods.findIndex(method => method.name === 'pdf');
-  let filteredMethods = methods;
-
-  if (pdfMethodIndex >= 0) {
-    filteredMethods = methods.slice(0, pdfMethodIndex);
-  }
-
-  return filteredMethods;
-}
-
 async function callMethods(methods = []) {
   for (const method of methods) {
     const args = method.args || [];
+    const name = method.name || '';
+
+    if (name === 'pdf') {
+      break;
+    }
+
     try {
-      await page[method.name](...args);
+      await page[name](...args);
     } catch (error) {
-      throw new PuppeteerBadRequest(`Puppeteer bad request: ${error.message}`);
+      throw new PuppeteerBadRequest(
+        `Puppeteer bad request: ${error.message}`
+      );
     }
   }
 }
@@ -102,6 +99,7 @@ export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) =>
   try {
     let browser = await launchBrowser(userDataDir);
     let page = await launchPage(browser);
+    page = await callMethods(pageMethods);
 
     const pdf = await generatePdf();
     return pdf;

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -12,8 +12,21 @@ function deleteUserDataDir(dirPath) {
   });
 }
 
-async function launchBrowser(userDataDir) {
-  try {
+async function callMethods(classObj, methods = []) {
+  const hasMethods = methods && methods.length;
+
+  if (hasMethods) {
+    for (const method of methods) { 
+      const args = method.args || [];
+      try {
+        await classObj[method.name](...args);
+      } catch (error) {
+        throw new PuppeteerBadRequest(`Puppeteer bad request: ${error.message}`);
+      }
+    }
+  }
+}
+
     const browser = await puppeteer.launch({
       ignoreHTTPSErrors: true,
       args: ['--no-sandbox'],

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -27,44 +27,45 @@ async function callMethods(classObj, methods = []) {
   }
 }
 
+async function launchBrowser(userDataDir, browserOptions) {
+  try {
     const browser = await puppeteer.launch({
       ignoreHTTPSErrors: true,
       args: ['--no-sandbox'],
       userDataDir
     });
-    
+
     browser.on('disconnected', () => {
       deleteUserDataDir(userDataDir);
     });
-    
+
+    if (browserOptions) {
+      await callMethods(browser, browserOptions.methods || []);
+    }
+
     return browser;
 
   } catch (error) {
     if (error instanceof puppeteer.errors.TimeoutError) {
-      throw new PuppeteerCrash('Puppeteer browser launch timeout');
+      throw new PuppeteerCrash(`Puppeteer browser launch timeout: ${error.message}`);
     } else {
-      throw new PuppeteerCrash('Puppeteer browser launch error');
+      throw new PuppeteerCrash(`Puppeteer browser launch error: ${error.message}`);
     }
   }
 }
 
-async function launchPage(browser) {
+async function launchPage(browser, pageOptions) {
   const page = await browser.newPage();
 
   page.on('error', () => {
     throw new PuppeteerCrash('Puppeteer launch page error');
   });
+  
+  if (pageOptions) {
+    await callMethods(page, pageOptions.methods || []);
+  }
 
   return page;
-}
-
-async function goToPage(page, url) {
-  try {
-    await page.goto(url, { waitUntil: 'networkidle0' });
-    return;
-  } catch (error) {
-    throw new PuppeteerBadRequest(error.message);
-  }
 }
 
 export const print = async (options = null) => {

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -28,14 +28,10 @@ async function goToPage(page, url) {
 }
 
 async function generatePdf(page, printUrl, pdfOptions, pageMethods) {
-  const pdfMethodArgs = pageMethods.reduce((acc, method) => {
-    if (method.name === 'pdf') {
-      acc = method.args ? method.args[0] : {}
-    }
-    return acc;
-  }, {});
+  const pdfMethod = pageMethods.find(({ name }) => name === 'pdf');
+  const pdfMethodArgs = pdfMethod?.args?.[0] || pdfOptions;
 
-  const pdfArgs = sanitizePdfArgs(pdfMethodArgs || pdfOptions);
+  const pdfArgs = sanitizePdfArgs(pdfMethodArgs);
 
   if (pageMethods.length === 0) {
     await goToPage(page, printUrl);

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -19,7 +19,29 @@ let methods = [];
 let options = {};
 let url = '';
 
+async function generatePdf() {
+  let pdfArgs = {};
+  let hasMethods = methods && methods.length;
+  let hasPdfMethod = false;
+
   if (hasMethods) {
+    hasPdfMethod = methods.find(method => method.name === 'pdf');
+  }
+
+  if (hasPdfMethod) {
+    const pdfMethodIndex = methods.findIndex(method => method.name === 'pdf')
+    pdfArgs = methods[pdfMethodIndex].args;
+  } else {
+    if (url) {
+      await page.goto({ url: url })
+      pdfArgs = options;
+    }
+  }
+
+  pdfArgs = clearPdfArgsPath(pdfArgs);
+  return page.pdf(pdfArgs);
+}
+
 function filterMethods() {
   const pdfMethodIndex = methods.findIndex(method => method.name === 'pdf');
   let filteredMethods = methods;

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -38,7 +38,7 @@ async function generatePdf(page, printUrl, pdfOptions, pageMethods) {
   const pdfArgs = sanitizePdfArgs(pdfMethodArgs || pdfOptions);
 
   if (pageMethods.length === 0) {
-    goToPage(page, printUrl);
+    await goToPage(page, printUrl);
   }
 
   return page.pdf(pdfArgs);

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -54,10 +54,19 @@ async function goToPage(page, url) {
   }
 }
 
-export const print = async (url, cookies) => {
+export const print = async (options = null) => {
   let browser = null;
   let page = null;
   const userDataDir = path.resolve(`temp/puppeteer/${uuidv4()}`);
+
+  const hasOptions = !!options;
+  let browserOptions = null;
+  let pageOptions = null;
+
+  if (hasOptions) {
+    [browserOptions] = options.filter(option => option.type === 'browser');
+    [pageOptions] = options.filter(option => option.type === 'page');
+  }
 
   try {
     browser = await launchBrowser(userDataDir);

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -40,15 +40,12 @@ async function generatePdf(page, printUrl, pdfOptions, pageMethods) {
 
 async function callMethods(page, methods = []) {
   for (const method of methods) {
-    const args = method.args || [];
-    const name = method.name || '';
-
-    if (name === 'pdf') {
+    if (method.name === 'pdf') {
       break;
     }
 
     try {
-      await page[name](...args);
+      await page[method.name](...method.args);
     } catch (error) {
       throw new PuppeteerBadRequest(
         `Puppeteer bad request: ${error.message}`

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -51,7 +51,7 @@ async function callMethods(page, methods = []) {
     }
 
     try {
-      await page[method.name](...method.args);
+      await page[method.name](...(method.args || {}));
     } catch (error) {
       throw new PuppeteerBadRequest(
         `Puppeteer bad request: ${error.message}`

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -25,9 +25,8 @@ async function callMethods(classObj, methods = []) {
       }
     }
   }
-}
 
-async function launchBrowser(userDataDir, browserOptions) {
+async function launchBrowser(userDataDir) {
   try {
     const browser = await puppeteer.launch({
       ignoreHTTPSErrors: true,
@@ -38,10 +37,6 @@ async function launchBrowser(userDataDir, browserOptions) {
     browser.on('disconnected', () => {
       deleteUserDataDir(userDataDir);
     });
-
-    if (browserOptions) {
-      await callMethods(browser, browserOptions.methods || []);
-    }
 
     return browser;
 

--- a/lib/print.mjs
+++ b/lib/print.mjs
@@ -19,26 +19,25 @@ function clearPdfArgsPath(args = {}) {
   return {};
 }
 
-async function generatePdf() {
+async function generatePdf(page, printUrl, pdfOptions, pageMethods) {
+  let pdfMethod = pageMethods.find(method => method.name === 'pdf');
   let pdfArgs = {};
-  let hasMethods = methods && methods.length;
-  let hasPdfMethod = false;
 
-  if (hasMethods) {
-    hasPdfMethod = methods.find(method => method.name === 'pdf');
-  }
-
-  if (hasPdfMethod) {
-    const pdfMethodIndex = methods.findIndex(method => method.name === 'pdf')
-    pdfArgs = methods[pdfMethodIndex].args;
+  if (pdfMethod) {
+    pdfArgs = pdfMethod.args || {};
   } else {
-    if (url) {
-      await page.goto({ url: url })
-      pdfArgs = options;
+    pdfArgs = pdfOptions;
+  }
+  pdfArgs = clearPdfArgsPath(pdfArgs);
+
+  if (pdfMethod) {
+    try {
+      await page.goto({ url: printUrl })
+    } catch (error) {
+      throw new PuppeteerBadRequest(`Puppeteer page goto error: ${error.message}`);
     }
   }
 
-  pdfArgs = clearPdfArgsPath(pdfArgs);
   return page.pdf(pdfArgs);
 }
 
@@ -101,7 +100,7 @@ export const print = async (printUrl = '', pdfOptions = {}, pageMethods = []) =>
     let page = await launchPage(browser);
     page = await callMethods(pageMethods);
 
-    const pdf = await generatePdf();
+    const pdf = await generatePdf(page, printUrl, pdfOptions, pageMethods);
     return pdf;
   } catch (error) {
     throw error;


### PR DESCRIPTION
# Usage
See: https://github.com/jiayingy/pulpperator/pull/5#issuecomment-803606985

# Changes
- Rewrote post request for `/print` to receive a list of puppeteer browser/page methods to be called before the generation of pdf
```
options = [ 
    { 
        type: <class_type>, // 'browser' or 'page' 
        methods: [
            {
                name: <puppeteer_method_name>,
                args: [<arg1>, <arg2>, ...]
            },
        ]
    }
];
```

# Motivation
- Allows users to customize the generation to their own needs 
    - e.g. emulateMediaType, setTimeout 